### PR TITLE
Closes #12 Update svg images

### DIFF
--- a/TOPzap-shade-1.svg
+++ b/TOPzap-shade-1.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="77px"
+	 height="153.8px" viewBox="0 0 77 153.8" style="enable-background:new 0 0 77 153.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDC2F;}
+	.st1{fill:#F7941D;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#EEB434;}
+	.st3{fill:#D47032;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#E09034;}
+	.st5{fill:#C94D30;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#D47032;}
+	.st7{fill:#BE1E2D;}
+	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#BE1E2D;}
+	.st9{fill:#880C18;}
+	.st10{fill:#E09034;}
+	.st11{fill:#EEB434;}
+	.st12{fill:#FFDC2F;}
+</style>
+<g id="Layer_2">
+</g>
+<g id="Layer_1">
+	<g>
+		<polygon class="st0" points="33.4,87 1.9,87 59,5.2 43.4,65 75,65 15.1,148.4 		"/>
+		<path class="st1" d="M56.7,10.3L42.1,66h31L17.8,143l17-57H3.8L56.7,10.3 M61.4,0L55,9.2L2.2,84.8L0,88h3.8h28.3l-16.2,54.5
+			l-3.4,11.4l6.9-9.6l55.3-76.9L77,64h-3.9H44.6l13.9-53.2L61.4,0L61.4,0z"/>
+	</g>
+</g>
+</svg>

--- a/TOPzap-shade-2.svg
+++ b/TOPzap-shade-2.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="77px"
+	 height="153.8px" viewBox="0 0 77 153.8" style="enable-background:new 0 0 77 153.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDC2F;}
+	.st1{fill:#F7941D;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#EEB434;}
+	.st3{fill:#D47032;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#E09034;}
+	.st5{fill:#C94D30;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#D47032;}
+	.st7{fill:#BE1E2D;}
+	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#BE1E2D;}
+	.st9{fill:#880C18;}
+	.st10{fill:#E09034;}
+	.st11{fill:#EEB434;}
+	.st12{fill:#FFDC2F;}
+</style>
+<g id="Layer_2">
+</g>
+<g id="Layer_1">
+	<g>
+		<polygon class="st2" points="33.4,87 1.9,87 59,5.2 43.4,65 75,65 15.1,148.4 		"/>
+		<path class="st3" d="M56.7,10.3L42.1,66h31L17.8,143l17-57H3.8L56.7,10.3 M61.4,0L55,9.2L2.2,84.8L0,88h3.8h28.3l-16.2,54.5
+			l-3.4,11.4l6.9-9.6l55.3-76.9L77,64h-3.9H44.6l13.9-53.2L61.4,0L61.4,0z"/>
+	</g>
+</g>
+</svg>

--- a/TOPzap-shade-3.svg
+++ b/TOPzap-shade-3.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="77px"
+	 height="153.8px" viewBox="0 0 77 153.8" style="enable-background:new 0 0 77 153.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDC2F;}
+	.st1{fill:#F7941D;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#EEB434;}
+	.st3{fill:#D47032;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#E09034;}
+	.st5{fill:#C94D30;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#D47032;}
+	.st7{fill:#BE1E2D;}
+	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#BE1E2D;}
+	.st9{fill:#880C18;}
+	.st10{fill:#E09034;}
+	.st11{fill:#EEB434;}
+	.st12{fill:#FFDC2F;}
+</style>
+<g id="Layer_2">
+</g>
+<g id="Layer_1">
+	<g>
+		<polygon class="st4" points="33.4,87 1.9,87 59,5.2 43.4,65 75,65 15.1,148.4 		"/>
+		<path class="st5" d="M56.7,10.3L42.1,66h31L17.8,143l17-57H3.8L56.7,10.3 M61.4,0L55,9.2L2.2,84.8L0,88h3.8h28.3l-16.2,54.5
+			l-3.4,11.4l6.9-9.6l55.3-76.9L77,64h-3.9H44.6l13.9-53.2L61.4,0L61.4,0z"/>
+	</g>
+</g>
+</svg>

--- a/TOPzap-shade-4.svg
+++ b/TOPzap-shade-4.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="77px"
+	 height="153.8px" viewBox="0 0 77 153.8" style="enable-background:new 0 0 77 153.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDC2F;}
+	.st1{fill:#F7941D;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#EEB434;}
+	.st3{fill:#D47032;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#E09034;}
+	.st5{fill:#C94D30;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#D47032;}
+	.st7{fill:#BE1E2D;}
+	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#BE1E2D;}
+	.st9{fill:#880C18;}
+	.st10{fill:#E09034;}
+	.st11{fill:#EEB434;}
+	.st12{fill:#FFDC2F;}
+</style>
+<g id="Layer_2">
+</g>
+<g id="Layer_1">
+	<g>
+		<polygon class="st6" points="33.4,87 1.9,87 59,5.2 43.4,65 75,65 15.1,148.4 		"/>
+		<path class="st7" d="M56.7,10.3L42.1,66h31L17.8,143l17-57H3.8L56.7,10.3 M61.4,0L55,9.2L2.2,84.8L0,88h3.8h28.3l-16.2,54.5
+			l-3.4,11.4l6.9-9.6l55.3-76.9L77,64h-3.9H44.6l13.9-53.2L61.4,0L61.4,0z"/>
+	</g>
+</g>
+</svg>

--- a/TOPzap-shade-5.svg
+++ b/TOPzap-shade-5.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="77px"
+	 height="153.8px" viewBox="0 0 77 153.8" style="enable-background:new 0 0 77 153.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDC2F;}
+	.st1{fill:#F7941D;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#EEB434;}
+	.st3{fill:#D47032;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#E09034;}
+	.st5{fill:#C94D30;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#D47032;}
+	.st7{fill:#BE1E2D;}
+	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#BE1E2D;}
+	.st9{fill:#880C18;}
+	.st10{fill:#E09034;}
+	.st11{fill:#EEB434;}
+	.st12{fill:#FFDC2F;}
+</style>
+<g id="Layer_2">
+</g>
+<g id="Layer_1">
+	<g>
+		<polygon class="st8" points="33.4,87 1.9,87 59,5.2 43.4,65 75,65 15.1,148.4 		"/>
+		<path class="st9" d="M56.7,10.3L42.1,66h31L17.8,143l17-57H3.8L56.7,10.3 M61.4,0L55,9.2L2.2,84.8L0,88h3.8h28.3l-16.2,54.5
+			l-3.4,11.4l6.9-9.6l55.3-76.9L77,64h-3.9H44.6l13.9-53.2L61.4,0L61.4,0z"/>
+	</g>
+</g>
+</svg>

--- a/index.js
+++ b/index.js
@@ -110,11 +110,11 @@ let form;
 
 //if you go with the tier level I suggest the below order for Tier 0 to 10:
 const svg_paths = {
-  red: "./TOPzap-shade-1.svg",    //tier 0
-  blue: "./TOPzap-shade-2.svg",   //tier 1
-  green: "./TOPzap-shade-3.svg",  //tier 2
-  orange: "./TOPzap-shade-4.svg", //tier 5
-  black: "./TOPzap-shade-5.svg"   //tier 10
+  red: "./TOPzap-shade-1.svg",    //tier 0  #ffdc2f
+  blue: "./TOPzap-shade-2.svg",   //tier 1  #eeb434
+  green: "./TOPzap-shade-3.svg",  //tier 2  #e09034
+  orange: "./TOPzap-shade-4.svg", //tier 5  #d47032
+  black: "./TOPzap-shade-5.svg"   //tier 10 #be1e2d
 }
 const generate_level = (color, o_tier, c_tier) => {
   return {

--- a/index.js
+++ b/index.js
@@ -109,11 +109,11 @@ let total_points = 0;
 let form;
 
 const svg_paths = {
-  red: "./zap.svg",
-  blue: "./zap.svg",
-  green: "./zap.svg",
-  orange: "./zap.svg",
-  black: "./zap.svg"
+  red: "./TOPzap-shade-1.svg",
+  blue: "./TOPzap-shade-2.svg",
+  green: "./TOPzap-shade-3.svg",
+  orange: "./TOPzap-shade-4.svg",
+  black: "./TOPzap-shade-5.svg"
 }
 const generate_level = (color, o_tier, c_tier) => {
   return {

--- a/index.js
+++ b/index.js
@@ -108,12 +108,13 @@ const tierPoints = { 0: 0, 1: 1, 2: 2, 3: 5, 4: 10 };
 let total_points = 0;
 let form;
 
+//if you go with the tier level I suggest the below order for Tier 0 to 10:
 const svg_paths = {
-  red: "./TOPzap-shade-1.svg",
-  blue: "./TOPzap-shade-2.svg",
-  green: "./TOPzap-shade-3.svg",
-  orange: "./TOPzap-shade-4.svg",
-  black: "./TOPzap-shade-5.svg"
+  red: "./TOPzap-shade-1.svg",    //tier 0
+  blue: "./TOPzap-shade-2.svg",   //tier 1
+  green: "./TOPzap-shade-3.svg",  //tier 2
+  orange: "./TOPzap-shade-4.svg", //tier 5
+  black: "./TOPzap-shade-5.svg"   //tier 10
 }
 const generate_level = (color, o_tier, c_tier) => {
   return {


### PR DESCRIPTION
I have added 5 SVG files and changed the corresponding paths in the index.js file. 

I also added commentary for the colors with a proposed tier scheme from light (yellow) to dark (red) which fits perfectly with the severity of the infringement.

I'd suggest also changing the box colors for type of infringement per tier once the above change is implemented. From a design perspective and readability I would propose color #cc9543 as used in the lightmode ffw button and the darkmode tier buttons for the specific infringements (toxic bhaviour, dogpiling etc). There will be no need to have separate colors for those if the zap colors will be tier-specific.