### PR TITLE
Fix: change wording of the zaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,8 @@
         <button class="t4 i0">Bigotry</button>
         <button class="t4 i1">Continued harrassment</button>
         <button class="t4 i2">NSFW or highly offensive content</button>
-        <button class="t4 i3">Doxxing</button>
-        <button class="t4 i4">Spamming</button>
+        <button class="t4 i3">Spamming</button>
+        <button class="t4 i4">Doxxing</button>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <button class="t2 i1">Unsolicited pings/DMs</button>
         <button class="t2 i2">Discussing politics/religion</button>
         <button class="t2 i3">Mild toxicity</button>
-        <button class="t2 i4">Self promoting</button>
+        <button class="t2 i4">Self promoting without permission</button>
       </div>
       <div class="lvl3 form hidden">
         <svg

--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
             d="M6 18L18 6M6 6l12 12"
           />
         </svg>
-        <button class="t0 i0">Dogpile</button>
-        <button class="t0 i1">Encourage Windows</button>
-        <button class="t0 i2">Chat Bomb</button>
-        <button class="t0 i3">Discuss Mental Health</button>
-        <button class="t0 i4">Inappropriate Username</button>
+        <button class="t0 i0">Dogpiling</button>
+        <button class="t0 i1">Discussing Windows</button>
+        <button class="t0 i2">Chat bombing</button>
+        <button class="t0 i3">Bringing in mental health issues</button>
+        <button class="t0 i4">Inappropriate profile</button>
       </div>
       <div class="lvl1 form hidden">
         <svg
@@ -68,9 +68,9 @@
             d="M6 18L18 6M6 6l12 12"
           />
         </svg>
-        <button class="t1 i0">Mini Mod</button>
-        <button class="t1 i1">Personal projects</button>
-        <button class="t1 i2">Unprofessionalism</button>
+        <button class="t1 i0">Mini-modding</button>
+        <button class="t1 i1">Requesting out of scope help</button>
+        <button class="t1 i2">Mild unprofessionalism</button>
       </div>
       <div class="lvl2 form hidden">
         <svg
@@ -88,11 +88,11 @@
             d="M6 18L18 6M6 6l12 12"
           />
         </svg>
-        <button class="t2 i0">Piracy</button>
-        <button class="t2 i1">Unsolicited Pings</button>
-        <button class="t2 i2">Politics/Religion</button>
-        <button class="t2 i3">Mildly Toxic</button>
-        <button class="t2 i4">Self Promotion</button>
+        <button class="t2 i0">Suggesting piracy</button>
+        <button class="t2 i1">Unsolicited pings/DMs</button>
+        <button class="t2 i2">Discussing politics/religion</button>
+        <button class="t2 i3">Mild toxicity</button>
+        <button class="t2 i4">Self promoting</button>
       </div>
       <div class="lvl3 form hidden">
         <svg
@@ -110,9 +110,9 @@
             d="M6 18L18 6M6 6l12 12"
           />
         </svg>
-        <button class="t3 i0">Illegal Activities</button>
-        <button class="t3 i1">Argue over warnings</button>
-        <button class="t3 i2">Exessively Toxic</button>
+        <button class="t3 i0">Discussing illegal activities</button>
+        <button class="t3 i1">Arguing over moderation</button>
+        <button class="t3 i2">Excessive toxicity</button>
       </div>
       <div class="lvl4 form hidden">
         <svg
@@ -131,10 +131,10 @@
           />
         </svg>
         <button class="t4 i0">Bigotry</button>
-        <button class="t4 i1">NSFW</button>
-        <button class="t4 i2">Harrassment</button>
-        <button class="t4 i3">Doxing</button>
-        <button class="t4 i4">Spam</button>
+        <button class="t4 i1">Continued harrassment</button>
+        <button class="t4 i2">NSFW or highly offensive content</button>
+        <button class="t4 i3">Doxxing</button>
+        <button class="t4 i4">Spamming</button>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <button class="t0 i0">Dogpiling</button>
         <button class="t0 i1">Discussing Windows</button>
         <button class="t0 i2">Chat bombing</button>
-        <button class="t0 i3">Bringing in mental health issues</button>
+        <button class="t0 i3">Bringing up mental health issues</button>
         <button class="t0 i4">Inappropriate profile</button>
       </div>
       <div class="lvl1 form hidden">

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             d="M6 18L18 6M6 6l12 12"
           />
         </svg>
-        <button class="t2 i0">Suggesting piracy</button>
+        <button class="t2 i0">Discussing piracy</button>
         <button class="t2 i1">Unsolicited pings/DMs</button>
         <button class="t2 i2">Discussing politics/religion</button>
         <button class="t2 i3">Mild toxicity</button>


### PR DESCRIPTION
Changes:

I have changed the wording of particular zap descriptions:
- Opted for present continuous 
- Made button order match the list order in the matrix
- Made wording resemble matrix wording whenever possible
- Typo and other various fixes

Mclilzee said:
> I don't think we need it to be verbose, but make it more clear. For example, there are Self promotion under spam offense, one guarantees a ban and another only gives you 2 zaps. Knowing the differentiation between them is important.

Issues like this I think are more about how Matrix is worded currently - the problem with self promotion being twice in the rules with different punishments while not having exclusive conditions is somewhat confusing. I believe that there's an implicit understanding that the 2 zap version of self promotion is about people who are doing TOP, while the 10 zap version of self promotion is about people who come from outside and just leave the message to see whether it sticks.

I must say that rewording the mental health zap is pretty hard since communicating the "in depth" or "seeking help" part in a laconic way seems impossible. Need feedback on this for sure.

Closes #32 