### PR TITLE
fix tier tags not being centered

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ const form = (function () {
   function addTierTags() {
     if(tierTagsAdded === true) return
     const buttons = document.querySelectorAll(
-      ".levels .combinedOffencesContainer .offenceContainer button"
+      ".levels .combined-offences-container .offence-container button"
     );
     buttons.forEach((button) => {
       const tag = document.createElement("span");


### PR DESCRIPTION
## Description
<!--Description of the change-->
Fixes 'Add Points:' text not getting styles applied to them, due to the text not being generated with a `span` tag.
## Additional information
<!--
If this PR resolves an existing issue, replace Closes #XXXXX with the issue number, e.g Closes #1052
If this PR is related to an existing issue but does not resolve it, please mention the issue without the Closes keyword.
 -->
