### PR TITLE
Adjust design of stats box

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,52 +158,72 @@
   <main class="main">
     <div class="grid">
       <div class="points-label-space"></div>
-      <div class="points-label">0 Points</div>
-      <div class="points-label">1 Point</div>
-      <div class="points-label">2 Points</div>
-      <div class="points-label">5 Points</div>
-      <div class="points-label">10 Points</div>
-      <div class="button-container">
-        <button class="zap-button" id="zap-index0">Commit Zap Tier 0</button>
+
+      <div class="points-labels">
+        <div class="points-label">0 Points</div>
+        <div class="points-label">1 Point</div>
+        <div class="points-label">2 Points</div>
+        <div class="points-label">5 Points</div>
+        <div class="points-label">10 Points</div>
       </div>
-      <div class="cell" id="t00"></div>
-      <div class="cell" id="t01"></div>
-      <div class="cell" id="t02"></div>
-      <div class="cell" id="t03"></div>
-      <div class="cell danger" id="t04"></div>
-      <div class="button-container">
-        <button class="zap-button" id="zap-index1">Commit Zap Tier 1</button>
+
+      <div class="zap-buttons">
+        <div class="button-container">
+          <button class="zap-button" id="zap-index0">Commit Zap Tier 0</button>
+        </div>
+
+        <div class="button-container">
+          <button class="zap-button" id="zap-index1">Commit Zap Tier 1</button>
+        </div>
+
+        <div class="button-container">
+          <button class="zap-button" id="zap-index2">Commit Zap Tier 2</button>
+        </div>
+
+        <div class="button-container">
+          <button class="zap-button" id="zap-index3">Commit Zap Tier 5</button>
+        </div>
+
+        <div class="button-container">
+          <button class="zap-button" id="zap-index4">Commit Zap Tier 10</button>
+        </div>
       </div>
-      <div class="cell skipped" id="t10"></div>
-      <div class="cell" id="t11"></div>
-      <div class="cell" id="t12"></div>
-      <div class="cell" id="t13"></div>
-      <div class="cell danger" id="t14"></div>
-      <div class="button-container">
-        <button class="zap-button" id="zap-index2">Commit Zap Tier 2</button>
+
+      
+      <div class="grid-cells">
+        <div class="cell" id="t00"></div>
+        <div class="cell" id="t01"></div>
+        <div class="cell" id="t02"></div>
+        <div class="cell" id="t03"></div>
+        <div class="cell danger" id="t04"></div>
+        
+        <div class="cell skipped" id="t10"></div>
+        <div class="cell" id="t11"></div>
+        <div class="cell" id="t12"></div>
+        <div class="cell" id="t13"></div>
+        <div class="cell danger" id="t14"></div>
+        
+        <div class="cell skipped" id="t20"></div>
+        <div class="cell skipped" id="t21"></div>
+        <div class="cell" id="t22"></div>
+        <div class="cell" id="t23"></div>
+        <div class="cell danger" id="t24"></div>
+        
+        <div class="cell skipped" id="t30"></div>
+        <div class="cell skipped" id="t31"></div>
+        <div class="cell skipped" id="t32"></div>
+        <div class="cell" id="t33"></div>
+        <div class="cell danger" id="t34"></div>
+        
+        <div class="cell skipped" id="t40"></div>
+        <div class="cell skipped" id="t41"></div>
+        <div class="cell skipped" id="t42"></div>
+        <div class="cell skipped" id="t43"></div>
+        <div class="cell danger" id="t44"></div>
       </div>
-      <div class="cell skipped" id="t20"></div>
-      <div class="cell skipped" id="t21"></div>
-      <div class="cell" id="t22"></div>
-      <div class="cell" id="t23"></div>
-      <div class="cell danger" id="t24"></div>
-      <div class="button-container">
-        <button class="zap-button" id="zap-index3">Commit Zap Tier 5</button>
-      </div>
-      <div class="cell skipped" id="t30"></div>
-      <div class="cell skipped" id="t31"></div>
-      <div class="cell skipped" id="t32"></div>
-      <div class="cell" id="t33"></div>
-      <div class="cell danger" id="t34"></div>
-      <div class="button-container">
-        <button class="zap-button" id="zap-index4">Commit Zap Tier 10</button>
-      </div>
-      <div class="cell skipped" id="t40"></div>
-      <div class="cell skipped" id="t41"></div>
-      <div class="cell skipped" id="t42"></div>
-      <div class="cell skipped" id="t43"></div>
-      <div class="cell danger" id="t44"></div>
     </div>
+
+
     <div class="stat-box">
       <div id="current-points-rank1" class="zap-points-label">
         Welcome, you are clean right now

--- a/style.css
+++ b/style.css
@@ -100,18 +100,26 @@ body {
 }
 
 .main {
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 3em;
-  padding-inline: 1em;
-}
+  gap: 4em;
+  padding: 0 3em;
+} 
+
 
 .grid {
+
   display: grid;
-  grid-template-columns: 2fr repeat(5, 1fr);
-  grid-template-rows: 1fr repeat(5, 2fr);
+  grid-template-columns: 2fr 5fr;
+  grid-template-rows: .5fr 5fr;
   aspect-ratio: 4/3;
+
+
+  grid-template-areas: 
+   '      .     point-labels' 
+   'zap-buttons    cells    ';
 }
 
 .theme-svg {
@@ -153,6 +161,12 @@ button:hover {
   transition: all 300ms;
 }
 
+.points-labels {
+  display: grid;
+  grid-area: point-labels;
+  grid-template-columns: repeat(5, 1fr);
+}
+
 .points-label {
   color: var(--color-accent);
   font-size: clamp(0.625rem, 0.3906rem + 1.0417vw, 0.9375rem);
@@ -162,15 +176,24 @@ button:hover {
 }
 
 .stat-box {
-  margin: 1%;
   color: var(--text-primary);
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 2.25fr 1fr;
+  grid-template-areas: 
+    'points  points'
+    'fastfoward reset';
+  width: 30%;
+
+  max-height: 550px;
+  align-items: start;
 }
 
 .zap-points-label {
   font-size: var(--fs-base);
-  margin-bottom: 0.5em;
+  grid-area: points;
+  height: 100%;
+  text-align: center;
 }
 
 .stat {
@@ -209,6 +232,7 @@ button:hover {
   transition: all ease-out 500ms;
   backdrop-filter: blur(5px);
 }
+
 .combined-offences-container {
   display: flex;
   gap: 1em;
@@ -217,6 +241,13 @@ button:hover {
   width: 90%;
   flex-wrap: wrap;
 }
+
+.zap-buttons {
+  grid-area: zap-buttons;
+  display: grid;
+  grid-template-rows: repeat(5, 1fr);
+}
+
 .zap-button {
   width: 80%;
   min-height: 80%;
@@ -266,6 +297,14 @@ button:hover {
   width: 100%;
 }
 
+.grid-cells {
+  grid-area: cells;
+
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+}
+
 .cell {
   display: flex;
   position: relative;
@@ -301,8 +340,18 @@ button:hover {
   background-color: var(--button-secondary);
   color: #fff;
   margin: 0.5em 0;
-  padding: 1em 2em;
-  max-width: 70%;
+  padding: 1em 1em;
+  width: 90%;
+  height: 80%;
+  max-height: 125px;
+}
+
+.reset-button {
+  grid-area: reset;
+}
+
+.time-travel-button {
+  grid-area: fastfoward;
 }
 
 .ref {
@@ -329,16 +378,18 @@ svg:hover {
   display: none;
 }
 
-@media only screen and (max-width: 680px) {
-  body {
-    gap: 0.5em;
-  }
+@media only screen and (max-width: 650px) {
+
+  
   .main {
     flex-direction: column;
+    justify-content: flex-start;
     width: 95%;
-    margin: 0 auto;
+   
     padding: 0;
+    gap: .5em;;
   }
+
 
   .cell {
     aspect-ratio: 1;
@@ -346,10 +397,26 @@ svg:hover {
 
   .stat-box {
     width: 100%;
-    align-items: center;
-    justify-content: center;
+    display: grid;
     font-size: 15px;
+    grid-template-areas: 
+    'points'
+    'fastfoward'
+    'reset';
+    grid-template-columns: 1fr;
+    grid-template-rows: 3fr 1fr 1fr;
+    text-align: center;
+    gap: 0;
   }
+
+  .reset-button,
+  .time-travel-button {
+    height: auto;
+    padding: 1.5em;
+    max-width: 50%;
+    justify-self: center;
+  }
+
 
   .disclaimer-message-container {
     width: 70%;


### PR DESCRIPTION
## Description
This change changes the design of the stats box for desktop layouts. The reset and fastfoward buttons are now displayed in a row instead of a column. This change also addresses issues with the entire layout shifting when new text is inserted into the `.stats-box` container.

## Additional information
<!--
If this PR resolves an existing issue, replace Closes #XXXXX with the issue number, e.g Closes #1052
If this PR is related to an existing issue but does not resolve it, please mention the issue without the Closes keyword.
 -->
Completes most tasks in issue #34
- [ ] Change the welcome message to something more descriptive
- [x] Change the size and positioning of the buttons (They should be stacked in a row on desktop while a column on phone)
- [x] Reduce the size of stats box buttons to match the zap buttons.
- [x] The should not be re-positioned when the text is inserted in the box

Closes #64 
